### PR TITLE
Update for release 1.3.0

### DIFF
--- a/node/config.ini
+++ b/node/config.ini
@@ -47,8 +47,6 @@ max-transaction-time = 10000
 max-irreversible-block-age = -1
 txn-reference-block-lag = 0
 
-unlock-timeout = 900
-
 plugin = eosio::chain_api_plugin
 plugin = eosio::history_api_plugin
 plugin = eosio::chain_plugin

--- a/wallet/start.sh
+++ b/wallet/start.sh
@@ -6,7 +6,9 @@ if ! [ -x "$JQ" ]; then
   echo 'Error: jq is not installed.' >&2
   exit 1
 fi
-CLEOS=$(command -v cleos)
+SCRIPTPATH=$(/usr/bin/dirname $( $REALPATH $0))""
+config="$SCRIPTPATH/../config.json"
+CLEOS="$( $JQ -r '.cleos_bin' "$config" )"
 if ! [ -x "$CLEOS" ]; then
   echo 'Error: cleos is not installed.' >&2
   exit 1


### PR DESCRIPTION
Removed the unlock-timeout option from nodeos config, which is no longer supported as of 1.3.0.  Also, respect the path for cleos in the config file vs relying on it being installed (in the path).